### PR TITLE
Fix workflow: remove duplicate test structure creation step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,6 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Create test structure
-        run: |
-          mkdir -p src/test/java
-          cp -r src/test/unit-tests/java/* src/test/java/ 2>/dev/null || true
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
- Eliminated the step that was creating src/test/java and copying files from src/test/unit-tests/java
- This was causing duplicate class errors in GitHub Actions
- The project already uses build-helper-maven-plugin for proper test source management